### PR TITLE
Remove Sudoers Usage

### DIFF
--- a/dcos-versions/1.9.0/dcos-mesos-agent-public/templates/install/run.sh
+++ b/dcos-versions/1.9.0/dcos-mesos-agent-public/templates/install/run.sh
@@ -3,5 +3,5 @@
 # Install Agent Node
 mkdir /tmp/dcos && cd /tmp/dcos
 /usr/bin/curl -O ${bootstrap_private_ip}:${dcos_bootstrap_port}/dcos_install.sh
-sudo bash dcos_install.sh slave_public
+bash dcos_install.sh slave_public
 # Agent Node End

--- a/dcos-versions/1.9.0/dcos-mesos-agent/templates/install/run.sh
+++ b/dcos-versions/1.9.0/dcos-mesos-agent/templates/install/run.sh
@@ -3,6 +3,6 @@
 # Install Agent Node
 mkdir /tmp/dcos && cd /tmp/dcos
 /usr/bin/curl -O ${bootstrap_private_ip}:${dcos_bootstrap_port}/dcos_install.sh
-sudo bash dcos_install.sh slave
+bash dcos_install.sh slave
 # Agent Node End
 

--- a/dcos-versions/1.9.0/dcos-mesos-master/templates/install/run.sh
+++ b/dcos-versions/1.9.0/dcos-mesos-master/templates/install/run.sh
@@ -3,5 +3,5 @@
 # Install Master Node
 mkdir /tmp/dcos && cd /tmp/dcos
 /usr/bin/curl -O ${bootstrap_private_ip}:${dcos_bootstrap_port}/dcos_install.sh
-sudo bash dcos_install.sh master
+bash dcos_install.sh master
 # Master Node End


### PR DESCRIPTION
I'm using tf_dcos_core in an auto-scaling group where the module scripts are executed by user-data in AWS EC2. I figured that some other people may be in the same situation, and want to have access to the auto scaling features for their masters and agents. The problem is, user-data scripts require a TTY to run sudo on centos in particular. 

This PR is partially complete on purpose to spark a conversation about whether or not we want to include sudoers usage in `run.sh`. If we remove it, the call to `sudo` can be added in the terraform code where we execute `run.sh` instead of in the script directly. This may break deployments for some people currently using this module.

All that being said, I still figured I'd make the PR and see what you think is best. If you're keen on this PR moving forward, I can remove `sudo` usage from all other `run.sh` scripts and clean up the commit history in the PR to make this complete.