### PR TITLE
support for overriding previous_version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
+.terraform
 *.bak

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This tf_dcos_core module takes care of all the installation, modification, and u
 
 ### Recommended Variables
 
+- `dcos_previous_version` - DC/OS 1.9+ requires users to set this value to ensure users know the version. Terraform helps populate this value, but users can override it here. (recommended)
 - `dcos_resolvers ` - A YAML nested list (-) of DNS resolvers for your DC/OS cluster nodes. (recommended)
 - `dcos_ip_detect_public_contents` - Allows DC/OS to be aware of your publicly routeable address for ease of use (recommended)
 - `dcos_security ` - [Enterprise DC/OS] set the security level of DC/OS. Default is permissive. (recommended)
@@ -161,6 +162,7 @@ This tf_dcos_core module takes care of all the installation, modification, and u
     dcos_overlay_mtu = "${var.dcos_overlay_mtu}"
     dcos_overlay_network = "${var.dcos_overlay_network}"
     dcos_process_timeout = "${var.dcos_process_timeout}"
+    dcos_previous_version = "${var.dcos_previous_version}"
     dcos_agent_list = "\n - ${join("\n - ", aws_instance.agent.*.private_ip)}"
     dcos_resolvers  = "\n - ${join("\n - ", var.dcos_resolvers)}"
     dcos_rexray_config_filename = "${var.dcos_rexray_config_filename}"
@@ -232,6 +234,7 @@ This tf_dcos_core module takes care of all the installation, modification, and u
     dcos_overlay_mtu = "${var.dcos_overlay_mtu}"
     dcos_overlay_network = "${var.dcos_overlay_network}"
     dcos_process_timeout = "${var.dcos_process_timeout}"
+    dcos_previous_version = "${var.dcos_previous_version}"
     dcos_resolvers  = "\n - ${join("\n - ", var.dcos_resolvers)}"
     dcos_rexray_config_filename = "${var.dcos_rexray_config_filename}"
     dcos_rexray_config_method = "${var.dcos_rexray_config_method}"

--- a/dcos-versions/1.9.0-rc1/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.9.0-rc1/dcos-bootstrap/templates/upgrade/run.sh
@@ -72,9 +72,10 @@ ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
 sudo cp /tmp/ip-detect genconf/.
+OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 PREVIOUS_DCOS_VERSION=$(grep -a "'dcos_version':" "$(find dcos_generate_config.* | tail -1)" | cut -d ":" -f2 | sed 's/,$//' | sed s/\'//g)
 curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
-sudo bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $PREVIOUS_DCOS_VERSION 
+sudo bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}}
 sudo rm -fr genconf/serve/upgrade/current
 sudo cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current
 sudo docker rm -f $(docker ps -a -q -f ancestor=nginx)

--- a/dcos-versions/1.9.0-rc2/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.9.0-rc2/dcos-bootstrap/templates/upgrade/run.sh
@@ -72,9 +72,10 @@ ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
 sudo cp /tmp/ip-detect genconf/.
+OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 PREVIOUS_DCOS_VERSION=$(grep -a "'dcos_version':" "$(find dcos_generate_config.* | tail -1)" | cut -d ":" -f2 | sed 's/,$//' | sed s/\'//g)
 curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
-sudo bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $PREVIOUS_DCOS_VERSION 
+sudo bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}}
 sudo rm -fr genconf/serve/upgrade/current
 sudo cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current
 sudo docker rm -f $(docker ps -a -q -f ancestor=nginx)

--- a/dcos-versions/1.9.0-rc3/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.9.0-rc3/dcos-bootstrap/templates/upgrade/run.sh
@@ -72,9 +72,10 @@ ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
 sudo cp /tmp/ip-detect genconf/.
+OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 PREVIOUS_DCOS_VERSION=$(grep -a "'dcos_version':" "$(find dcos_generate_config.* | tail -1)" | cut -d ":" -f2 | sed 's/,$//' | sed s/\'//g)
 curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
-sudo bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $PREVIOUS_DCOS_VERSION 
+sudo bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}}
 sudo rm -fr genconf/serve/upgrade/current
 sudo cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current
 sudo docker rm -f $(docker ps -a -q -f ancestor=nginx)

--- a/dcos-versions/1.9.0-rc4/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.9.0-rc4/dcos-bootstrap/templates/upgrade/run.sh
@@ -72,9 +72,10 @@ ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
 sudo cp /tmp/ip-detect genconf/.
+OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 PREVIOUS_DCOS_VERSION=$(grep -a "'dcos_version':" "$(find dcos_generate_config.* | tail -1)" | cut -d ":" -f2 | sed 's/,$//' | sed s/\'//g)
 curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
-sudo bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $PREVIOUS_DCOS_VERSION 
+sudo bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}}
 sudo rm -fr genconf/serve/upgrade/current
 sudo cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current
 sudo docker rm -f $(docker ps -a -q -f ancestor=nginx)

--- a/dcos-versions/1.9.0/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.9.0/dcos-bootstrap/templates/upgrade/run.sh
@@ -72,9 +72,10 @@ ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
 sudo cp /tmp/ip-detect genconf/.
+OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 PREVIOUS_DCOS_VERSION=$(grep -a "'dcos_version':" "$(find dcos_generate_config.* | tail -1)" | cut -d ":" -f2 | sed 's/,$//' | sed s/\'//g)
 curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
-sudo bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $PREVIOUS_DCOS_VERSION 
+sudo bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}}
 sudo rm -fr genconf/serve/upgrade/current
 sudo cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current
 sudo docker rm -f $(docker ps -a -q -f ancestor=nginx)

--- a/dcos-versions/1.9.1/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.9.1/dcos-bootstrap/templates/upgrade/run.sh
@@ -72,9 +72,10 @@ ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
 sudo cp /tmp/ip-detect genconf/.
+OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 PREVIOUS_DCOS_VERSION=$(grep -a "'dcos_version':" "$(find dcos_generate_config.* | tail -1)" | cut -d ":" -f2 | sed 's/,$//' | sed s/\'//g)
 curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
-sudo bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $PREVIOUS_DCOS_VERSION 
+sudo bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}}
 sudo rm -fr genconf/serve/upgrade/current
 sudo cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current
 sudo docker rm -f $(docker ps -a -q -f ancestor=nginx)

--- a/dcos-versions/1.9.2/dcos-bootstrap/templates/upgrade/run.sh
+++ b/dcos-versions/1.9.2/dcos-bootstrap/templates/upgrade/run.sh
@@ -72,9 +72,10 @@ ${dcos_staged_package_storage_uri == "" ? "" : "  staged_package_storage_uri: ${
 ${dcos_package_storage_uri == "" ? "" : "  package_storage_uri: ${dcos_package_storage_uri}"}
 EOF
 sudo cp /tmp/ip-detect genconf/.
+OVERRIDE_PREVIOUS_DCOS_VERSION=${dcos_previous_version}
 PREVIOUS_DCOS_VERSION=$(grep -a "'dcos_version':" "$(find dcos_generate_config.* | tail -1)" | cut -d ":" -f2 | sed 's/,$//' | sed s/\'//g)
 curl -o dcos_generate_config.${dcos_version}.sh ${dcos_download_path}
-sudo bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $PREVIOUS_DCOS_VERSION 
+sudo bash dcos_generate_config.${dcos_version}.sh --generate-node-upgrade-script $${OVERRIDE_PREVIOUS_DCOS_VERSION:-$${PREVIOUS_DCOS_VERSION}}
 sudo rm -fr genconf/serve/upgrade/current
 sudo cp -r genconf/serve/upgrade/$(ls -1tr genconf/serve/upgrade/ | tail -1) genconf/serve/upgrade/current
 sudo docker rm -f $(docker ps -a -q -f ancestor=nginx)

--- a/main.tf
+++ b/main.tf
@@ -54,6 +54,7 @@ template = "${file("${path.module}/dcos-versions/${var.dcos_version}/${var.role}
     dcos_overlay_network = "${var.dcos_overlay_network}"
     dcos_process_timeout = "${var.dcos_process_timeout}"
     dcos_public_agent_list = "${var.dcos_public_agent_list}"
+    dcos_previous_version = "${var.dcos_previous_version}"
     dcos_resolvers  = "${var.dcos_resolvers}"
     dcos_rexray_config_filename = "${var.dcos_rexray_config_filename}"
     dcos_rexray_config_method = "${var.dcos_rexray_config_method}"

--- a/variables.tf
+++ b/variables.tf
@@ -256,6 +256,10 @@ variable "dcos_public_agent_list" {
    default = ""
 }
 
+variable "dcos_previous_version" {
+   default = ""
+}
+
 variable "dcos_agent_list" {
    default = ""
 }


### PR DESCRIPTION
Tested this by removing the bootstrap node and overriding the `dcos_previous_version`. 